### PR TITLE
Fix configured station radius handling for config entry sensors

### DIFF
--- a/custom_components/hungaromet/daily_sensor.py
+++ b/custom_components/hungaromet/daily_sensor.py
@@ -19,6 +19,7 @@ class HungarometWeatherDailySensor(SensorEntity):
         self._unique_id = f"{self._device_id}_{self._name.lower().replace(' ', '_')}"
         self._added = False
         self.coordinator = coordinator
+        self._distance_km = DEFAULT_DISTANCE_KM
 
     @property
     def name(self):
@@ -72,13 +73,12 @@ class HungarometWeatherDailySensor(SensorEntity):
     async def async_update_data(self):
         if not self._added:
             return
-
         # Use coordinator data if available, otherwise fetch directly
         if self.coordinator and self.coordinator.data:
             data = self.coordinator.data.get("data", {})
         else:
             data, _ = await self.hass.async_add_executor_job(
-                process_daily_data, self.hass, DEFAULT_DISTANCE_KM
+                process_daily_data, self.hass, self._distance_km
             )
 
         value = data.get(self._key)

--- a/custom_components/hungaromet/hourly_sensor.py
+++ b/custom_components/hungaromet/hourly_sensor.py
@@ -21,6 +21,7 @@ class HungarometWeatherHourlySensor(SensorEntity):
         self._unique_id = f"{self._device_id}_{self._name.lower().replace(' ', '_')}"
         self._added = False
         self.coordinator = coordinator
+        self._distance_km = DEFAULT_DISTANCE_KM
 
     @property
     def name(self):
@@ -77,13 +78,12 @@ class HungarometWeatherHourlySensor(SensorEntity):
     async def async_update_data(self):
         if not self._added:
             return
-
         # Use coordinator data if available, otherwise fetch directly
         if self.coordinator and self.coordinator.data:
             data = self.coordinator.data.get("data", {})
         else:
             data, _ = await self.hass.async_add_executor_job(
-                process_hourly_data, self.hass, DEFAULT_DISTANCE_KM
+                process_hourly_data, self.hass, self._distance_km
             )
 
         # Try both the raw key and the 'average_' + key

--- a/custom_components/hungaromet/sensor.py
+++ b/custom_components/hungaromet/sensor.py
@@ -73,7 +73,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         daily_data, station_info = await hass.async_add_executor_job(
             process_daily_data, hass, distance_km
         )
-        hourly_data, _ = await hass.async_add_executor_job(process_hourly_data, hass)
+        hourly_data, _ = await hass.async_add_executor_job(
+            process_hourly_data, hass, distance_km
+        )
         ten_minutes_data, _ = await hass.async_add_executor_job(
             process_ten_minutes_data, hass, distance_km
         )
@@ -145,6 +147,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     except Exception as err:  # pragma: no cover - defensive logging
         _LOGGER.error("Failed to fetch/process weather data: %s", err)
         return
+    for sensor in sensors:
+        setattr(sensor, "_distance_km", distance_km)
     async_add_entities(sensors, True)
 
     # Register update service
@@ -192,15 +196,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             # Fetch data once
             if data_type == "hourly":
                 data, _ = await hass.async_add_executor_job(
-                    process_hourly_data, hass, DEFAULT_DISTANCE_KM
+                    process_hourly_data, hass, distance_km
                 )
             elif data_type == "ten_minutes":
                 data, _ = await hass.async_add_executor_job(
-                    process_ten_minutes_data, hass, DEFAULT_DISTANCE_KM
+                    process_ten_minutes_data, hass, distance_km
                 )
             elif data_type == "daily":
                 data, _ = await hass.async_add_executor_job(
-                    process_daily_data, hass, DEFAULT_DISTANCE_KM
+                    process_daily_data, hass, distance_km
                 )
             else:
                 return
@@ -263,10 +267,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
+    distance_km = entry.data.get(CONF_DISTANCE_KM, DEFAULT_DISTANCE_KM)
     sensors = []
     try:
         data, station_info = await hass.async_add_executor_job(
-            process_daily_data, hass, DEFAULT_DISTANCE_KM
+            process_daily_data, hass, distance_km
         )
         sensors.append(
             HungarometWeatherDailySensor(
@@ -382,7 +387,7 @@ async def async_setup_entry(
         )
 
         data, station_info = await hass.async_add_executor_job(
-            process_hourly_data, hass, DEFAULT_DISTANCE_KM
+            process_hourly_data, hass, distance_km
         )
         sensors.append(
             HungarometWeatherHourlySensor(
@@ -507,7 +512,7 @@ async def async_setup_entry(
         )
 
         data, station_info = await hass.async_add_executor_job(
-            process_ten_minutes_data, hass, DEFAULT_DISTANCE_KM
+            process_ten_minutes_data, hass, distance_km
         )
         sensors.append(
             HungarometWeatherTenMinutesSensor(
@@ -631,6 +636,8 @@ async def async_setup_entry(
     except Exception as err:  # pragma: no cover - defensive logging
         _LOGGER.error("Failed to fetch/process weather data: %s", err)
         return
+    for sensor in sensors:
+        setattr(sensor, "_distance_km", distance_km)
     async_add_entities(sensors, True)
 
     async def handle_update_service(call):
@@ -677,15 +684,15 @@ async def async_setup_entry(
             # Fetch data once
             if data_type == "hourly":
                 data, _ = await hass.async_add_executor_job(
-                    process_hourly_data, hass, DEFAULT_DISTANCE_KM
+                    process_hourly_data, hass, distance_km
                 )
             elif data_type == "ten_minutes":
                 data, _ = await hass.async_add_executor_job(
-                    process_ten_minutes_data, hass, DEFAULT_DISTANCE_KM
+                    process_ten_minutes_data, hass, distance_km
                 )
             elif data_type == "daily":
                 data, _ = await hass.async_add_executor_job(
-                    process_daily_data, hass, DEFAULT_DISTANCE_KM
+                    process_daily_data, hass, distance_km
                 )
             else:
                 return

--- a/custom_components/hungaromet/station_info_sensor.py
+++ b/custom_components/hungaromet/station_info_sensor.py
@@ -2,18 +2,27 @@ import logging
 
 from homeassistant.components.sensor import SensorEntity
 
+from .const import DEFAULT_DISTANCE_KM
 from .weather_data import process_daily_data
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class HungarometStationInfoSensor(SensorEntity):
-    def __init__(self, hass, name, station_info, sensor_type="daily"):
+    def __init__(
+        self,
+        hass,
+        name,
+        station_info,
+        sensor_type="daily",
+        distance_km=DEFAULT_DISTANCE_KM,
+    ):
         self.hass = hass
         self._name = name
         self._station_info = station_info
         self._device_id = "hungaromet_weather"
         self._sensor_type = sensor_type
+        self._distance_km = distance_km
         self._unique_id = f"{self._device_id}_station_info_{sensor_type}"
         self._added = False
 
@@ -62,7 +71,7 @@ class HungarometStationInfoSensor(SensorEntity):
         if not self._added:
             return
         _, stations = await self.hass.async_add_executor_job(
-            process_daily_data, self.hass
+            process_daily_data, self.hass, self._distance_km
         )
         self._station_info = stations
         self.async_write_ha_state()

--- a/custom_components/hungaromet/ten_minutes_sensor.py
+++ b/custom_components/hungaromet/ten_minutes_sensor.py
@@ -21,6 +21,7 @@ class HungarometWeatherTenMinutesSensor(SensorEntity):
         self._unique_id = f"{self._device_id}_{self._name.lower().replace(' ', '_')}"
         self._added = False
         self.coordinator = coordinator
+        self._distance_km = DEFAULT_DISTANCE_KM
 
     @property
     def name(self):
@@ -77,13 +78,12 @@ class HungarometWeatherTenMinutesSensor(SensorEntity):
     async def async_update_data(self):
         if not self._added:
             return
-
         # Use coordinator data if available, otherwise fetch directly
         if self.coordinator and self.coordinator.data:
             data = self.coordinator.data.get("data", {})
         else:
             data, _ = await self.hass.async_add_executor_job(
-                process_ten_minutes_data, self.hass, DEFAULT_DISTANCE_KM
+                process_ten_minutes_data, self.hass, self._distance_km
             )
 
         # Try both the raw key and the 'average_' + key


### PR DESCRIPTION
This PR fixes an issue where the configured station search radius was ignored by config-entry based sensors.

The integration already stores the configured radius using `CONF_DISTANCE_KM`, but several config-entry setup and update paths used `DEFAULT_DISTANCE_KM` instead of the configured value. As a result, changing the radius in the UI did not affect station filtering for those sensors, and the default 20 km radius was used instead.

Observed locally around Eger:

* Configured radius: 5 km
* Expected result: only the Eger station should be used
* Actual result before this fix: stations within the default 20 km radius were still included
* After this fix: the configured 5 km radius is used, and only the Eger station remains

The patch keeps the existing behavior intact and only passes the configured radius through the relevant config-entry setup and update paths.

Tested locally in Home Assistant with the HungaroMet integration configured to 5 km around Eger.
